### PR TITLE
Adds openssl 1.0.2 Chocolatey package

### DIFF
--- a/package/openssl/legal/LICENSE.txt
+++ b/package/openssl/legal/LICENSE.txt
@@ -1,0 +1,125 @@
+
+  LICENSE ISSUES
+  ==============
+
+  The OpenSSL toolkit stays under a double license, i.e. both the conditions of
+  the OpenSSL License and the original SSLeay license apply to the toolkit.
+  See below for the actual license texts.
+
+  OpenSSL License
+  ---------------
+
+/* ====================================================================
+ * Copyright (c) 1998-2017 The OpenSSL Project.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer. 
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. All advertising materials mentioning features or use of this
+ *    software must display the following acknowledgment:
+ *    "This product includes software developed by the OpenSSL Project
+ *    for use in the OpenSSL Toolkit. (http://www.openssl.org/)"
+ *
+ * 4. The names "OpenSSL Toolkit" and "OpenSSL Project" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For written permission, please contact
+ *    openssl-core@openssl.org.
+ *
+ * 5. Products derived from this software may not be called "OpenSSL"
+ *    nor may "OpenSSL" appear in their names without prior written
+ *    permission of the OpenSSL Project.
+ *
+ * 6. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by the OpenSSL Project
+ *    for use in the OpenSSL Toolkit (http://www.openssl.org/)"
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT ``AS IS'' AND ANY
+ * EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR
+ * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * ====================================================================
+ *
+ * This product includes cryptographic software written by Eric Young
+ * (eay@cryptsoft.com).  This product includes software written by Tim
+ * Hudson (tjh@cryptsoft.com).
+ *
+ */
+
+ Original SSLeay License
+ -----------------------
+
+/* Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)
+ * All rights reserved.
+ *
+ * This package is an SSL implementation written
+ * by Eric Young (eay@cryptsoft.com).
+ * The implementation was written so as to conform with Netscapes SSL.
+ * 
+ * This library is free for commercial and non-commercial use as long as
+ * the following conditions are aheared to.  The following conditions
+ * apply to all code found in this distribution, be it the RC4, RSA,
+ * lhash, DES, etc., code; not just the SSL code.  The SSL documentation
+ * included with this distribution is covered by the same copyright terms
+ * except that the holder is Tim Hudson (tjh@cryptsoft.com).
+ * 
+ * Copyright remains Eric Young's, and as such any Copyright notices in
+ * the code are not to be removed.
+ * If this package is used in a product, Eric Young should be given attribution
+ * as the author of the parts of the library used.
+ * This can be in the form of a textual message at program startup or
+ * in documentation (online or textual) provided with the package.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *    "This product includes cryptographic software written by
+ *     Eric Young (eay@cryptsoft.com)"
+ *    The word 'cryptographic' can be left out if the rouines from the library
+ *    being used are not cryptographic related :-).
+ * 4. If you include any Windows specific code (or a derivative thereof) from 
+ *    the apps directory (application code) you must include an acknowledgement:
+ *    "This product includes software written by Tim Hudson (tjh@cryptsoft.com)"
+ * 
+ * THIS SOFTWARE IS PROVIDED BY ERIC YOUNG ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ * 
+ * The licence and distribution terms for any publically available version or
+ * derivative of this code cannot be changed.  i.e. this code cannot simply be
+ * copied and put under another distribution licence
+ * [including the GNU Public Licence.]
+ */
+

--- a/package/openssl/legal/VERIFICATION.txt
+++ b/package/openssl/legal/VERIFICATION.txt
@@ -1,0 +1,21 @@
+VERIFICATION
+Verification is intended to assist the Chocolatey moderators and community
+in verifying that this package's contents are trustworthy.
+
+The embedded software have been downloaded from the listed download
+location on <https://slproweb.com/products/Win32OpenSSL.html>
+and can be verified by doing the following:
+
+1. Download the following:
+  32-Bit software: <https://slproweb.com/download/Win32OpenSSL-1_0_2q.exe>
+  64-Bit software: <https://slproweb.com/download/Win64OpenSSL-1_0_2q.exe>
+2. Get the checksum using one of the following methods:
+  - Using powershell function 'Get-FileHash'
+  - Use chocolatey utility 'checksum.exe'
+3. The checksums should match the following:
+
+  checksum type: sha256
+  checksum32: D6B5C46EF7410B0C397F25D55CFD7BB4A5BC040308274041A55F917D9F091305
+  checksum64: AA661CFEF57F84808E77545A83F61DCC1AB98140BCADFF102682435FE0B00763
+
+The file 'LICENSE.txt' has been obtained from <https://www.openssl.org/source/license.txt>

--- a/package/openssl/openssl.nuspec
+++ b/package/openssl/openssl.nuspec
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>OpenSSL</id>
+    <version>1.1.1.20181020</version>
+    <packageSourceUrl>https://github.com/ros2/choco-packages/tree/latest/package/openssl</packageSourceUrl>
+    <owners>AWS RoboMaker</owners>
+    <title>OpenSSL – The Open Source SSL and TLS toolkit</title>
+    <authors>Shining Productions</authors>
+    <projectUrl>https://slproweb.com/products/Win32OpenSSL.html</projectUrl>
+    <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey/chocolatey-coreteampackages@1a1a45ece68d4852cc454cf9354d9a441516fccc/icons/openssl.png</iconUrl>
+    <copyright>Ⓒ 2000-2003 Shining Productions</copyright>
+    <licenseUrl>https://www.openssl.org/source/license.html</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <tags>openssl ssl tls pfx pem key rsa admin foss cross-platform</tags>
+    <summary>Open Source SSL v2/v3 and TLS v1 toolkit</summary>
+    <description><![CDATA[
+The OpenSSL Project is a collaborative effort to develop a robust, commercial-grade, full-featured, and Open Source toolkit implementing the Secure Sockets Layer (SSL v2/v3) and Transport Layer Security (TLS v1) protocols as well as a full-strength general purpose cryptography library. The project is managed by a worldwide community of volunteers that use the Internet to communicate, plan, and develop the OpenSSL toolkit and its related documentation.
+
+The Win32 OpenSSL Installation Project is dedicated to providing a simple installation of OpenSSL. It is easy to set up and easy to use through the simple, effective installer. No need to compile anything or jump through any hoops, just click a few times and it is installed, leaving you to doing real work. Download it today! Note that these are default builds of OpenSSL and subject to local and state laws. More information can be found in the legal agreement of the installation.
+
+## Package Parameters
+- `/InstallDir:`- Installation directory, defaults to the 'Program Files\OpenSSL' directory.
+
+Example: `choco install openssl.light --params "/InstallDir:C:\your\install\path"`
+]]></description>
+    <dependencies>
+      <dependency id="chocolatey" version="0.10.5" />
+      <dependency id="chocolatey-core.extension" version="1.3.3" />
+      <dependency id="vcredist140" version="14.12.25810" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="legal\**" target="legal" />
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/package/openssl/tools/ChocolateyInstall.ps1
+++ b/package/openssl/tools/ChocolateyInstall.ps1
@@ -1,0 +1,27 @@
+﻿$ErrorActionPreference = 'Stop'
+
+$toolsPath = Split-Path $MyInvocation.MyCommand.Definition
+
+$pp = Get-PackageParameters
+$silentArgs =  '/silent','/sp-','/suppressmsgboxes'
+$silentArgs += '/DIR="{0}"' -f $( if ($pp.InstallDir) { $pp.InstallDir } else { "$Env:ProgramFiles\OpenSSL" } )
+
+$packageArgs = @{
+  packageName    = 'OpenSSL'
+  fileType       = 'exe'
+  file           = "$toolsPath\Win32OpenSSL-1_0_2q.exe"
+  file64         = "$toolsPath\Win64OpenSSL-1_0_2q.exe"
+  softwareName   = 'OpenSSL*'
+  silentArgs     = $silentArgs
+  validExitCodes = @(0)
+}
+
+Install-ChocolateyInstallPackage @packageArgs
+Remove-Item -Force -ea 0 "$toolsPath\*.exe","$toolsPath\*.ignore"
+
+$installLocation = Get-AppInstallLocation $packageArgs.softwareName
+if (!$installLocation)  { Write-Warning "Can't find install location, PATH not updated"; return }
+Write-Host "Installed to '$installLocation'"
+
+Install-ChocolateyPath -PathToInstall "$installLocation\bin" -PathType Machine
+Install-ChocolateyEnvironmentVariable OPENSSL_CONF "$(Join-Path $installLocation bin\openssl.cfg)" Machine

--- a/package/openssl/update.ps1
+++ b/package/openssl/update.ps1
@@ -1,0 +1,13 @@
+﻿Import-Module AU
+
+function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix }
+function global:au_GetLatest {
+  @{
+    URL32 = "https://slproweb.com/download/Win32OpenSSL-1_0_2q.exe"
+    URL64 = "https://slproweb.com/download/Win64OpenSSL-1_0_2q.exe"
+    Version = "1.0.2"
+    PackageName = 'OpenSSL'
+  }
+}
+
+update -ChecksumFor none


### PR DESCRIPTION
Based on ROS 2 Source install documentation:
https://index.ros.org/doc/ros2/Installation/Windows-Install-Binary/#install-openssl

This package is a Chocolatey automatic package:
https://chocolatey.org/docs/automatic-packages

To build and install this package:

```
$ cinst au
$ cd packages/openssl
$ ./update.ps1
$ Get-RemoteFiles -Purge -NoSuffix
$ choco pack
$ cinst -s . openssl -y
```